### PR TITLE
Add getBufferSize macro to I-OStream

### DIFF
--- a/Examples/Stream-InOut/main.c
+++ b/Examples/Stream-InOut/main.c
@@ -65,14 +65,14 @@ int main()
 	// flush buffer and transmit bytes as possible
 	printf("Space: %u\n", OStream_space(&outStream));
 	printf("Flush to Media..\n");
-	printArray(Stream_getBuffer(&outStream), Stream_getBufferSize(&outStream));
+	printArray(OStream_getDataPtr(&outStream), OStream_getBufferSize(&outStream));
 	OStream_flush(&outStream);
 
 	// start receive
 	printf("Start receive from Media..\n");
 	IStream_receive(&inStream);
 	printf("Available: %u\n", IStream_available(&inStream));
-	printArray(Stream_getBuffer(&inStream), Stream_getBufferSize(&inStream));
+	printArray(IStream_getDataPtr(&outStream), IStream_getBufferSize(&inStream));
 
 	printf("V0: %d\n", IStream_readInt32(&inStream));
 	printf("V1: %d\n", IStream_readInt8(&inStream));

--- a/Src/InputStream.h
+++ b/Src/InputStream.h
@@ -119,6 +119,7 @@ Stream_LenType IStream_incomingBytes(IStream* stream);
 #endif // ISTREAM_LOCK
 
 #define IStream_getDataPtr(STREAM)                  Stream_getWritePtr(&((STREAM)->Buffer))
+#define IStream_getBufferSize(STREAM)               Stream_getBufferSize(&((STREAM)->Buffer))
 
 #define IStream_clear(STREAM)                       Stream_clear(&((STREAM)->Buffer))
 #define IStream_reset(STREAM)                       Stream_reset(&((STREAM)->Buffer))

--- a/Src/OutputStream.h
+++ b/Src/OutputStream.h
@@ -148,6 +148,7 @@ Stream_LenType OStream_outgoingBytes(OStream* stream);
 #define OStream_pendingBytes(STREAM)                Stream_available(&((STREAM)->Buffer))
 
 #define OStream_getDataPtr(STREAM)                  Stream_getReadPtr(&((STREAM)->Buffer))
+#define OStream_getBufferSize(STREAM)               Stream_getBufferSize(&((STREAM)->Buffer))
 
 #define OStream_clear(STREAM)                       Stream_clear(&((STREAM)->Buffer))
 #define OStream_reset(STREAM)                       Stream_reset(&((STREAM)->Buffer))


### PR DESCRIPTION
 - Fix InOut example
 - Add getBufferSize macro to I-OStream 